### PR TITLE
Add Static Web Apps CI/CD workflow and enhance Bicep templates for DNS management

### DIFF
--- a/.github/workflows/ci-cd-swa.yml
+++ b/.github/workflows/ci-cd-swa.yml
@@ -1,0 +1,45 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  build_and_deploy_job:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
+        with:
+          action: "upload"
+          app_location: "/"
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          output_location: "public"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          HUGO_VERSION: 0.145.0
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+    - name: Close Pull Request
+      id: closepullrequest
+      uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
+      with:
+        action: 'close'
+        app_location: "/"
+        azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 public/
 resources/_gen/
 .hugo_build.lock
+*.bicepparam

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,18 +1,39 @@
-@sys.allowed([
-  'dev'
-  'prod'
-])
-param environment string = 'dev'
+@sys.description('The name of the DNS CNAME record to create.')
+param dnsZoneRecordName string
 
-param githubRepositoryBranch string = 'master'
+@sys.description('The Azure Resource ID of the DNS zone to create the CNAME record in.')
+param dnsZoneResourceId string
 
-param gitHubRepositoryUrl string = 'https://github.com/RylandDeGregory/Blog'
+@sys.description('The branch of the GitHub repository to use. Default: main')
+param githubRepositoryBranch string = 'main'
 
-param location string = 'eastus2'
+@sys.description('The URL of the GitHub repository to use.')
+param gitHubRepositoryUrl string
 
-param staticWebAppName string = 'swa-blog-use2-${environment}'
+@sys.description('Azure location for the static web app. Default: resourceGroup().location')
+param location string = resourceGroup().location
 
+@sys.description('The name of the static web app to create.')
+param staticWebAppName string
+
+@sys.description('Dictionary of Azure tags to apply to the resources.')
 param tags object = {}
+
+var customDomainName = dnsZoneRecordName == '@' ? dnsZoneName : '${dnsZoneRecordName}.${dnsZoneName}'
+
+var dnsZoneSubscriptionId = split(dnsZoneResourceId, '/')[2]
+var dnsZoneResourceGroupName = split(dnsZoneResourceId, '/')[4]
+var dnsZoneName = split(dnsZoneResourceId, '/')[8]
+
+module dns 'modules/dns.bicep' = {
+  name: 'DNS'
+  params: {
+    dnsZoneName: dnsZoneName
+    dnsCnameRecordName: dnsZoneRecordName
+    dnsCnameRecordValue: staticWebApp.properties.defaultHostname
+  }
+  scope: resourceGroup(dnsZoneSubscriptionId, dnsZoneResourceGroupName)
+}
 
 resource staticWebApp 'Microsoft.Web/staticSites@2025-03-01' = {
   name: staticWebAppName
@@ -33,4 +54,14 @@ resource staticWebApp 'Microsoft.Web/staticSites@2025-03-01' = {
     stagingEnvironmentPolicy: 'Enabled'
   }
   tags: tags
+
+  resource customDomain 'customDomains' = {
+    name: customDomainName
+    properties: {
+      validationMethod: 'cname-delegation'
+    }
+    dependsOn: [
+      dns
+    ]
+  }
 }

--- a/infra/modules/dns.bicep
+++ b/infra/modules/dns.bicep
@@ -1,0 +1,22 @@
+@sys.description('The name of the DNS zone to create the CNAME record in.')
+param dnsZoneName string
+
+@sys.description('The name of the CNAME record to create.')
+param dnsCnameRecordName string
+
+@sys.description('The value of the CNAME record to create.')
+param dnsCnameRecordValue string
+
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
+  name: dnsZoneName
+
+  resource cnameRecord 'CNAME' = {
+    name: dnsCnameRecordName
+    properties: {
+      TTL: 3600
+      CNAMERecord: {
+        cname: dnsCnameRecordValue
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for building and deploying the blog to Azure Static Web Apps, including PR preview environments and cleanup on close
- Enhance the Bicep templates to manage a custom domain via a DNS CNAME record
- Parameterize `main.bicep` (remove hardcoded environment/naming assumptions) and add descriptions to all params
- Add a new `modules/dns.bicep` module that creates a CNAME record in an existing DNS zone (supports cross-subscription/resource-group scope)
- Wire up the Static Web App `customDomains` child resource with `cname-delegation` validation, dependent on the DNS record
- Ignore `*.bicepparam` files in `.gitignore`

## Notes
- The DNS module targets an existing zone resolved from `dnsZoneResourceId`, so subscription, resource group, and zone name are derived from the resource ID
- Actions are pinned to commit SHAs for supply-chain safety

## Test plan
- [ ] Validate/what-if the Bicep deployment against the target subscription
- [ ] Confirm the SWA custom domain provisions and DNS CNAME resolves
- [ ] Verify the CI/CD workflow builds Hugo and deploys on push to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)